### PR TITLE
Add hyperlinks for talks and interviews in chat messages

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -53,6 +53,12 @@ export default async function HomePage() {
   const peopleLinks = allPeople.docs.filter((p: any) => p.linkedIn).map((p: any) => ({ name: p.name, linkedin: p.linkedIn }))
   const allSideProjects = await payload.find({ collection: 'side-projects', sort: 'order', limit: 100, depth: 0 })
   const sideProjectLinks = allSideProjects.docs.filter((p: any) => p.slug).map((p: any) => ({ title: p.title, slug: p.slug }))
+  const aboutPage = await payload.find({ collection: 'pages', where: { slug: { equals: 'about' } }, depth: 0, limit: 1 })
+  const aboutData = aboutPage.docs[0] as any
+  const talkLinks = [
+    ...((aboutData?.talks || []) as any[]).filter((t: any) => t.url).map((t: any) => ({ title: t.title, url: t.url })),
+    ...((aboutData?.interviews || []) as any[]).filter((t: any) => t.url).map((t: any) => ({ title: t.title, url: t.url })),
+  ]
 
   const sections = (page?.sections || []) as any[]
   const aboutSection = sections.find((s: any) => s.blockType === 'aboutSection')
@@ -327,14 +333,14 @@ export default async function HomePage() {
               <div className="flex flex-col tablet:grid tablet:grid-cols-6 gap-5 tablet:gap-10 h-full">
                 {block.title && <div className="tablet:col-span-2 flex items-start"><h3>{block.title}</h3></div>}
                 <div className="tablet:col-span-4 bg-background-alt rounded-[20px] tablet:rounded-[30px] p-5 tablet:p-8 tablet:h-full tablet:min-h-[400px] overflow-hidden" style={{ height: block.fixedHeight || '70dvh' }}>
-                  <Chat faqItems={faqItems} avatarUrl={aboutImage} avatarUrlDark={aboutImageDark} projects={projectLinks} sideProjects={sideProjectLinks} people={peopleLinks} socialLinks={socialLinks} />
+                  <Chat faqItems={faqItems} avatarUrl={aboutImage} avatarUrlDark={aboutImageDark} projects={projectLinks} sideProjects={sideProjectLinks} people={peopleLinks} socialLinks={socialLinks} talks={talkLinks} />
                 </div>
               </div>
             ) : (
               <div className="flex flex-col h-full">
                 {block.title && <h3 className="pb-5 tablet:pb-10">{block.title}</h3>}
                 <div className="bg-background-alt rounded-[20px] tablet:rounded-[30px] p-5 tablet:p-8 tablet:flex-1 min-h-0 overflow-hidden" style={{ height: block.fixedHeight || '70dvh' }}>
-                  <Chat faqItems={faqItems} avatarUrl={aboutImage} avatarUrlDark={aboutImageDark} projects={projectLinks} sideProjects={sideProjectLinks} people={peopleLinks} socialLinks={socialLinks} />
+                  <Chat faqItems={faqItems} avatarUrl={aboutImage} avatarUrlDark={aboutImageDark} projects={projectLinks} sideProjects={sideProjectLinks} people={peopleLinks} socialLinks={socialLinks} talks={talkLinks} />
                 </div>
               </div>
             )}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -33,6 +33,11 @@ type PersonLink = {
   linkedin: string
 }
 
+type TalkLink = {
+  title: string
+  url: string
+}
+
 function stripMarkdown(text: string): string {
   return text
     .replace(/\*\*(.+?)\*\*/g, '$1')
@@ -43,7 +48,7 @@ function stripMarkdown(text: string): string {
 
 const linkStyle = { textDecoration: 'underline', textUnderlineOffset: '3px' }
 
-function linkify(text: string, projects: ProjectLink[], blogPosts: BlogPost[] = [], people: PersonLink[] = [], sideProjects: { title: string; slug: string }[] = []): React.ReactNode[] {
+function linkify(text: string, projects: ProjectLink[], blogPosts: BlogPost[] = [], people: PersonLink[] = [], sideProjects: { title: string; slug: string }[] = [], talks: TalkLink[] = []): React.ReactNode[] {
   text = stripMarkdown(text)
 
   const sortedProjects = [...projects].sort((a, b) => b.title.length - a.title.length)
@@ -52,18 +57,22 @@ function linkify(text: string, projects: ProjectLink[], blogPosts: BlogPost[] = 
   const peopleNames = sortedPeople.map((p) => p.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
   const sortedSideProjects = [...sideProjects].sort((a, b) => b.title.length - a.title.length)
   const sideProjectNames = sortedSideProjects.map((p) => p.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const sortedTalks = [...talks].sort((a, b) => b.title.length - a.title.length)
+  const talkNames = sortedTalks.map((t) => t.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
 
-  // Match: [text](url), emails, bare URLs, project names, side project names, or people names
+  // Match: [text](url), emails, bare URLs, project names, side project names, talk names, or people names
   const mdLink = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/
   const email = /[\w.-]+@[\w.-]+\.\w+/
   const url = /https?:\/\/[^\s),]+/
   const projectPat = projectNames.length ? new RegExp(`\\b(${projectNames.join('|')})\\b`, 'i') : null
   const sideProjectPat = sideProjectNames.length ? new RegExp(`\\b(${sideProjectNames.join('|')})\\b`, 'i') : null
+  const talkPat = talkNames.length ? new RegExp(`"(${talkNames.join('|')})"`, 'i') : null
   const peoplePat = peopleNames.length ? new RegExp(`\\b(${peopleNames.join('|')})\\b`, 'i') : null
 
   const patterns = [mdLink.source, email.source, url.source]
   if (projectPat) patterns.push(projectPat.source)
   if (sideProjectPat) patterns.push(sideProjectPat.source)
+  if (talkPat) patterns.push(talkPat.source)
   if (peoplePat) patterns.push(peoplePat.source)
   const combined = new RegExp(`(${patterns.join('|')})`, 'gi')
 
@@ -126,17 +135,29 @@ function linkify(text: string, projects: ProjectLink[], blogPosts: BlogPost[] = 
             </a>,
           )
         } else {
-        const person = sortedPeople.find((p) => p.name.toLowerCase() === matched.toLowerCase())
-        if (person) {
-          parts.push(
-            <a key={key++} href={person.linkedin} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-              {matched}
-            </a>,
-          )
-        } else {
-          parts.push(matched)
+          // Check for talk/interview titles (matched includes surrounding quotes)
+          const talkTitleMatch = matched.match(/^"(.+)"$/)
+          const talkTitle = talkTitleMatch ? talkTitleMatch[1] : null
+          const talk = talkTitle ? sortedTalks.find((t) => t.title.toLowerCase() === talkTitle.toLowerCase()) : null
+          if (talk) {
+            parts.push(
+              <span key={key++}>
+                &quot;<a href={talk.url} target="_blank" rel="noopener noreferrer" style={linkStyle}>{talkTitle}</a>&quot;
+              </span>,
+            )
+          } else {
+            const person = sortedPeople.find((p) => p.name.toLowerCase() === matched.toLowerCase())
+            if (person) {
+              parts.push(
+                <a key={key++} href={person.linkedin} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+                  {matched}
+                </a>,
+              )
+            } else {
+              parts.push(matched)
+            }
+          }
         }
-      }
       }
     }
 
@@ -159,6 +180,7 @@ function AssistantMessage({
   people = [],
   sideProjects = [],
   blogPosts = [],
+  talks = [],
   animate = true,
 }: {
   paragraphs: string[]
@@ -169,6 +191,7 @@ function AssistantMessage({
   people?: PersonLink[]
   sideProjects?: { title: string; slug: string }[]
   blogPosts?: BlogPost[]
+  talks?: TalkLink[]
   animate?: boolean
 }) {
   const [visibleCount, setVisibleCount] = useState(animate ? 1 : paragraphs.length)
@@ -203,7 +226,7 @@ function AssistantMessage({
             style={animate ? { animation: 'bubbleIn 0.35s cubic-bezier(0.16, 1, 0.3, 1) both' } : undefined}
           >
             {text ? (
-              linkify(text, projects, blogPosts, people, sideProjects)
+              linkify(text, projects, blogPosts, people, sideProjects, talks)
             ) : (
               <span className="inline-flex items-center gap-1 py-1">
                 <span className="w-1.5 h-1.5 bg-current opacity-40 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
@@ -300,6 +323,7 @@ export function Chat({
   sideProjects = [],
   people = [],
   socialLinks = [],
+  talks = [],
 }: {
   faqItems: FAQItem[]
   avatarUrl?: string
@@ -308,6 +332,7 @@ export function Chat({
   sideProjects?: { title: string; slug: string }[]
   people?: PersonLink[]
   socialLinks?: SocialLink[]
+  talks?: TalkLink[]
 }) {
   const [messages, setMessages] = useState<Message[]>([{ role: 'assistant', content: GREETINGS[0] }])
   const [showLinks, setShowLinks] = useState(false)
@@ -675,6 +700,7 @@ export function Chat({
                 people={people}
                 sideProjects={sideProjects}
                 blogPosts={blogPosts}
+                talks={talks}
                 animate={animateBubbles}
               />
             )


### PR DESCRIPTION
Talks and interview titles mentioned in chat (e.g. "Designing At The Speed
of Startups", "The Future Belongs to Fractional Designers") are now
automatically linked to their URLs when surrounded by quotes.

https://claude.ai/code/session_016vCPjzWnx4FvVtE49n6B86