### PR TITLE
Fix email notifications not sending when visitors message

### DIFF
--- a/src/app/(frontend)/chat/conversations/[id]/route.ts
+++ b/src/app/(frontend)/chat/conversations/[id]/route.ts
@@ -1,4 +1,5 @@
 import { getPayload } from '@/lib/payload'
+import { sendNotification } from '../../notify/send'
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -26,6 +27,11 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       id,
       data: { messages },
     })
+
+    // Send email notification in the background
+    const title = (doc as any).title || ''
+    sendNotification({ conversationId: id, title, messages }).catch(() => {})
+
     return Response.json(doc)
   } catch {
     return Response.json({ error: 'Not found' }, { status: 404 })

--- a/src/app/(frontend)/chat/conversations/route.ts
+++ b/src/app/(frontend)/chat/conversations/route.ts
@@ -1,4 +1,5 @@
 import { getPayload } from '@/lib/payload'
+import { sendNotification } from '../notify/send'
 
 export async function GET() {
   const payload = await getPayload()
@@ -23,6 +24,9 @@ export async function POST(req: Request) {
     collection: 'conversations',
     data: { title, location: location || '', messages },
   })
+
+  // Send email notification in the background
+  sendNotification({ conversationId: doc.id, title, messages }).catch(() => {})
 
   return Response.json(doc)
 }

--- a/src/app/(frontend)/chat/notify/route.ts
+++ b/src/app/(frontend)/chat/notify/route.ts
@@ -1,27 +1,14 @@
-import { Resend } from 'resend'
+import { sendNotification } from './send'
 
 export async function POST(req: Request) {
-  const resend = new Resend(process.env.RESEND_API_KEY)
   const { conversationId, title, messages } = await req.json()
 
   if (!messages?.length) {
     return Response.json({ error: 'No messages' }, { status: 400 })
   }
 
-  const userMessages = messages.filter((m: any) => m.role === 'user')
-  const lastUserMessage = userMessages[userMessages.length - 1]?.content || ''
-  const preview = messages
-    .slice(-6)
-    .map((m: any) => `${m.role === 'user' ? '→' : '←'} ${m.content.replace(/\{\{FOLLOWUPS:.*?\}\}/g, '').trim()}`)
-    .join('\n\n')
-
   try {
-    await resend.emails.send({
-      from: 'Portfolio Chat <onboarding@resend.dev>',
-      to: 'gabe@valdivia.works',
-      subject: `New chat: "${lastUserMessage.slice(0, 60)}${lastUserMessage.length > 60 ? '...' : ''}"`,
-      text: `New conversation on your portfolio${title ? ` (${title})` : ''}.\n\nRecent messages:\n\n${preview}\n\n—\nView in admin: ${process.env.NEXT_PUBLIC_SERVER_URL || 'https://gabrielvaldivia.com'}/admin/collections/conversations/${conversationId}`,
-    })
+    await sendNotification({ conversationId, title, messages })
     return Response.json({ ok: true })
   } catch (e: any) {
     console.error('Email notification failed:', e.message)

--- a/src/app/(frontend)/chat/notify/send.ts
+++ b/src/app/(frontend)/chat/notify/send.ts
@@ -1,0 +1,30 @@
+import { Resend } from 'resend'
+
+interface NotifyParams {
+  conversationId: string | number
+  title: string
+  messages: { role: string; content: string }[]
+}
+
+export async function sendNotification({ conversationId, title, messages }: NotifyParams) {
+  if (!messages?.length) return
+
+  const resend = new Resend(process.env.RESEND_API_KEY)
+
+  const userMessages = messages.filter((m) => m.role === 'user')
+  const lastUserMessage = userMessages[userMessages.length - 1]?.content || ''
+  const preview = messages
+    .slice(-6)
+    .map(
+      (m) =>
+        `${m.role === 'user' ? '\u2192' : '\u2190'} ${m.content.replace(/\{\{FOLLOWUPS:.*?\}\}/g, '').trim()}`,
+    )
+    .join('\n\n')
+
+  await resend.emails.send({
+    from: 'Portfolio Chat <onboarding@resend.dev>',
+    to: 'gabe@valdivia.works',
+    subject: `New chat: "${lastUserMessage.slice(0, 60)}${lastUserMessage.length > 60 ? '...' : ''}"`,
+    text: `New conversation on your portfolio${title ? ` (${title})` : ''}.\n\nRecent messages:\n\n${preview}\n\n\u2014\nView in admin: ${process.env.NEXT_PUBLIC_SERVER_URL || 'https://gabrielvaldivia.com'}/admin/collections/conversations/${conversationId}`,
+  })
+}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -349,8 +349,6 @@ export function Chat({
   const hasRandomized = useRef(false)
   const locationRef = useRef('')
   const [blogPosts, setBlogPosts] = useState<BlogPost[]>([])
-  const notifyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const hasNotified = useRef(false)
 
   useEffect(() => {
     // Check for ?chat= URL param first
@@ -479,9 +477,6 @@ export function Chat({
   async function sendMessage(text: string) {
     if (!text.trim() || isStreaming) return
     userScrolledUp.current = false
-    hasNotified.current = false
-    if (notifyTimer.current) clearTimeout(notifyTimer.current)
-
     const userMessage: Message = { role: 'user', content: text.trim() }
     const newMessages = [...messages, userMessage]
     setMessages(newMessages)
@@ -568,26 +563,6 @@ export function Chat({
         .catch(() => {})
     }
 
-    // Schedule email notification 1 min after last response
-    if (!isStreaming && messages.some((m) => m.role === 'user')) {
-      if (notifyTimer.current) clearTimeout(notifyTimer.current)
-      hasNotified.current = false
-      notifyTimer.current = setTimeout(() => {
-        if (hasNotified.current) return
-        hasNotified.current = true
-        const id = conversationId
-        if (!id) return
-        fetch('/chat/notify', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            conversationId: id,
-            title: formatDate(new Date()) + (locationRef.current ? ` · ${locationRef.current}` : ''),
-            messages,
-          }),
-        }).catch(() => {})
-      }, 60000)
-    }
   }, [isStreaming])
 
   function loadConversations() {


### PR DESCRIPTION
The email notification was triggered by a 60-second client-side timer in
Chat.tsx. If visitors closed the tab before 60 seconds (which most do),
the notification never fired. Moved notification to server-side
conversation save endpoints so it fires immediately when a conversation
is created or updated, regardless of client state.

https://claude.ai/code/session_01CPjF4XTEYqenwgoXssjgc8