### PR TITLE
Fix clients schema drift with Payload migrations workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "payload migrate && next build",
     "start": "next start",
+    "migrate": "payload migrate",
+    "migrate:create": "payload migrate:create",
+    "migrate:status": "payload migrate:status",
     "generate:types": "payload generate:types",
     "generate:importmap": "payload generate:importmap"
   },

--- a/src/migrations/20260616_053500_add_client_details_active.ts
+++ b/src/migrations/20260616_053500_add_client_details_active.ts
@@ -1,0 +1,20 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+// Adds the `details` and `active` columns to the `clients` table. These fields
+// were added to the Clients collection in code but, because the database runs
+// with `push: false` and had no migrations, the columns were never created in
+// the production database — causing every query that reads a client to fail
+// with `column "details" does not exist`.
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "clients" ADD COLUMN IF NOT EXISTS "details" varchar;
+    ALTER TABLE "clients" ADD COLUMN IF NOT EXISTS "active" boolean DEFAULT false;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "clients" DROP COLUMN IF EXISTS "details";
+    ALTER TABLE "clients" DROP COLUMN IF EXISTS "active";
+  `)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,9 @@
+import * as migration_20260616_053500_add_client_details_active from './20260616_053500_add_client_details_active'
+
+export const migrations = [
+  {
+    up: migration_20260616_053500_add_client_details_active.up,
+    down: migration_20260616_053500_add_client_details_active.down,
+    name: '20260616_053500_add_client_details_active',
+  },
+]

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -40,6 +40,7 @@ export default buildConfig({
       connectionString: process.env.DATABASE_URI || '',
     },
     push: false,
+    migrationDir: path.resolve(dirname, 'migrations'),
   }),
   sharp,
   plugins: [


### PR DESCRIPTION
## Problem

Opening any client in the CMS admin (e.g. `/admin/collections/clients/33`) threw a server-side 500, and `/api/chat` plus every page that reads clients (`/people`, `/work/[slug]`, `/clients`) logged:

```
⨯ Error: Failed query: select … column … does not exist
```

### Root cause

The Clients collection gained `details` and `active` fields (commit `718655c`), but the database runs with `push: false` and had **no migrations directory** and no migrate step in the build. So the matching columns were never created in the production Postgres database. Every Payload query that selects a client row references a column that doesn't exist, which Postgres rejects.

This wasn't specific to the "Build Anything" client — any client record triggered it. The public clients page only looked fine because it was serving a previously cached render.

## Fix

- Add `src/migrations/` with a migration that adds the missing columns (idempotent `ADD COLUMN IF NOT EXISTS`).
- Set `migrationDir` on the Postgres adapter.
- Run `payload migrate` before `next build` so schema changes apply on every deploy. Add `migrate`, `migrate:create`, and `migrate:status` scripts.

## Notes

- `DATABASE_URI` must be available at build time on Vercel (it already is at runtime). If migrate can't reach the DB the build fails loudly, which is the safe behavior.
- The migration is idempotent, so it's safe even if a column already exists.

https://claude.ai/code/session_011modFk13ToSUxM8z7LcU6v

---
_Generated by [Claude Code](https://claude.ai/code/session_011modFk13ToSUxM8z7LcU6v)_